### PR TITLE
fix: use UserStore in ProfileCard component

### DIFF
--- a/src/features/buyer/profile/components/ProfileCard.tsx
+++ b/src/features/buyer/profile/components/ProfileCard.tsx
@@ -1,9 +1,16 @@
+import { useUser } from '@/shared/stores/userStore';
+
 export function ProfileCard() {
+  const { name, email } = useUser();
+
   return (
     <div className="bg-custom-card-background rounded-lg p-6 border border-white/30 shadow-[0_0_10px_0_rgba(255,255,255,0.1)] flex flex-col items-center">
       <div className="w-24 h-24 rounded-full bg-gray-700 mb-4 border-4 border-white/20" />
       <div className="text-white text-xl font-semibold mb-1">
-        Matias Aguilar
+        {name || 'User Name'}
+      </div>
+      <div className="text-gray-400 text-sm mb-1">
+        {email || 'user@example.com'}
       </div>
       <div className="text-purple-400 text-sm mb-4">Premium Member</div>
       <button className="flex items-center justify-center w-10 h-10 rounded-full border border-white/20 text-white hover:bg-gray-800">


### PR DESCRIPTION
Closes #261

## Changes
- Import `useUser` hook from `@/shared/stores/userStore`
- Replace hardcoded name ("Matias Aguilar") with dynamic `name` from store
- Add dynamic email display from store
- Add fallback values for empty data

/attempt 261