### PR TITLE
Add limited time drop service layer

### DIFF
--- a/src/shared/services/limited_time_drop/README.md
+++ b/src/shared/services/limited_time_drop/README.md
@@ -1,0 +1,59 @@
+# Limited Time Drop Service
+
+Type-safe service layer for the Limited Time Drop Soroban contract used by the StarShop frontend.
+
+## Structure
+
+```text
+src/shared/services/limited_time_drop/
+  limited_drop.service.ts
+  constants/drop.constants.ts
+  types/drop.types.ts
+  types/access.types.ts
+  utils/drop.utils.ts
+  index.ts
+```
+
+## Core API
+
+```ts
+import { LimitedTimeDropService } from '@/shared/services/limited_time_drop';
+
+const drops = new LimitedTimeDropService();
+
+await drops.createDrop({
+  title: 'Launch Drop',
+  productId: 1n,
+  maxSupply: 100,
+  startTime: 1735689600n,
+  endTime: 1735776000n,
+  price: 10000000n,
+  perUserLimit: 2,
+  imageUri: 'ipfs://...'
+});
+
+await drops.getDrop(1);
+await drops.participateInDrop(1, { quantity: 1 });
+await drops.trackParticipation(1);
+await drops.getDropStatus(1);
+await drops.getTimeRemaining(1);
+```
+
+## Access Control
+
+```ts
+await drops.checkAccess(1, userAddress);
+await drops.grantAccess(1, userAddress, adminAddress);
+await drops.revokeAccess(1, userAddress, adminAddress);
+await drops.updateUserLevel({
+  user: userAddress,
+  admin: adminAddress,
+  level: UserAccessLevel.PREMIUM
+});
+```
+
+The generated contract exposes whitelist writes and buyer-list reads, but it does not expose a whitelist enumeration method. `getAccessList()` therefore returns the on-chain buyer list for the drop and marks the source as `contract_buyers`.
+
+## Contract Limitations
+
+The current generated contract supports status updates through `update_status`, but does not expose field-level drop updates or end-time extensions. `updateDrop()` maps to status updates, `cancelDrop()` maps to the cancelled status, and `extendDrop()` returns a typed unsupported-operation response.

--- a/src/shared/services/limited_time_drop/constants/drop.constants.ts
+++ b/src/shared/services/limited_time_drop/constants/drop.constants.ts
@@ -1,0 +1,127 @@
+import { DropLifecycleStatus, UserAccessLevel } from '../types/drop.types';
+
+export const NETWORKS = {
+  testnet: {
+    contractId: 'CASRZ5EIYSNTLJZCIFYKKIKLPQ74XR64N3FBYYRBN6OYC7WPOZFKCPHM',
+    networkPassphrase: 'Test SDF Network ; September 2015',
+    rpcUrl: 'https://soroban-testnet.stellar.org',
+    isTestnet: true
+  },
+  mainnet: {
+    contractId: 'MAINNET_CONTRACT_ID',
+    networkPassphrase: 'Public Global Stellar Network ; September 2015',
+    rpcUrl: 'https://horizon.stellar.org',
+    isTestnet: false
+  }
+} as const;
+
+export const DEFAULT_CONFIG = {
+  TIMEOUT_SECONDS: 30,
+  FEE: 100000,
+  SIMULATE: true,
+  RETRY: {
+    maxRetries: 3,
+    baseDelay: 1000,
+    maxDelay: 10000,
+    backoffMultiplier: 2
+  },
+  CACHE: {
+    enabled: true,
+    ttl: 300000,
+    maxSize: 1000
+  }
+} as const;
+
+export const CONTRACT_METHODS = {
+  INITIALIZE: 'initialize',
+  CREATE_DROP: 'create_drop',
+  PURCHASE: 'purchase',
+  GET_DROP: 'get_drop',
+  GET_PURCHASE_HISTORY: 'get_purchase_history',
+  GET_DROP_PURCHASES: 'get_drop_purchases',
+  GET_BUYER_LIST: 'get_buyer_list',
+  ADD_TO_WHITELIST: 'add_to_whitelist',
+  REMOVE_FROM_WHITELIST: 'remove_from_whitelist',
+  SET_USER_LEVEL: 'set_user_level',
+  UPDATE_STATUS: 'update_status'
+} as const;
+
+export const CACHE_KEYS = {
+  DROP: (dropId: number) => `limited_drop:${dropId}`,
+  DROP_STATUS: (dropId: number) => `limited_drop:${dropId}:status`,
+  DROP_PURCHASES: (dropId: number) => `limited_drop:${dropId}:purchases`,
+  BUYER_LIST: (dropId: number) => `limited_drop:${dropId}:buyers`,
+  PURCHASE_HISTORY: (user: string, dropId: number) => `limited_drop:${dropId}:history:${user}`,
+  ACCESS: (user: string, dropId: number) => `limited_drop:${dropId}:access:${user}`,
+  PERFORMANCE_METRICS: 'limited_drop:performance_metrics',
+  HEALTH_CHECK: 'limited_drop:health_check'
+} as const;
+
+export const VALIDATION = {
+  ADDRESS: {
+    MIN_LENGTH: 56,
+    MAX_LENGTH: 56,
+    PATTERN: /^G[A-Z0-9]{55}$/
+  },
+  DROP: {
+    TITLE_MAX_LENGTH: 120,
+    IMAGE_URI_MAX_LENGTH: 500,
+    MIN_SUPPLY: 1,
+    MAX_SUPPLY: 1_000_000,
+    MIN_PRICE: 0n,
+    MIN_DURATION_SECONDS: 60n,
+    MAX_DURATION_SECONDS: 31_536_000n,
+    MIN_PER_USER_LIMIT: 1,
+    MAX_PER_USER_LIMIT: 10_000
+  },
+  PARTICIPATION: {
+    MIN_QUANTITY: 1,
+    MAX_QUANTITY: 10_000
+  }
+} as const;
+
+export const DROP_STATUS_LABELS = {
+  [DropLifecycleStatus.PENDING]: 'Pending',
+  [DropLifecycleStatus.ACTIVE]: 'Active',
+  [DropLifecycleStatus.COMPLETED]: 'Completed',
+  [DropLifecycleStatus.CANCELLED]: 'Cancelled'
+} as const;
+
+export const USER_LEVEL_LABELS = {
+  [UserAccessLevel.STANDARD]: 'Standard',
+  [UserAccessLevel.PREMIUM]: 'Premium',
+  [UserAccessLevel.VERIFIED]: 'Verified'
+} as const;
+
+export const ERROR_MESSAGES = {
+  NOT_INITIALIZED: 'Limited time drop service is not initialized',
+  WALLET_NOT_CONNECTED: 'Wallet not connected. Please connect your wallet first.',
+  INVALID_ADMIN: 'Invalid admin address format',
+  INVALID_USER: 'Invalid user address format',
+  INVALID_DROP_ID: 'Invalid drop ID',
+  INVALID_DROP_CONFIG: 'Invalid drop configuration',
+  INVALID_QUANTITY: 'Invalid participation quantity',
+  UNSUPPORTED_DROP_UPDATE: 'The contract only supports status updates for existing drops',
+  UNSUPPORTED_DROP_EXTENSION: 'The contract does not expose an end-time extension method'
+} as const;
+
+export const CONTRACT_ERROR_CODES = {
+  1: 'NotInitialized',
+  2: 'AlreadyInitialized',
+  3: 'Unauthorized',
+  4: 'DropNotFound',
+  5: 'DropNotActive',
+  6: 'DropEnded',
+  7: 'DropNotStarted',
+  8: 'InsufficientSupply',
+  9: 'UserLimitExceeded',
+  10: 'InvalidQuantity',
+  11: 'InvalidTime',
+  12: 'InvalidPrice',
+  13: 'NotWhitelisted',
+  14: 'InsufficientLevel',
+  15: 'InvalidUserLevel',
+  16: 'PurchaseFailed',
+  17: 'DuplicateWhitelistEntry',
+  18: 'InvalidStatusTransition'
+} as const;

--- a/src/shared/services/limited_time_drop/index.ts
+++ b/src/shared/services/limited_time_drop/index.ts
@@ -1,0 +1,38 @@
+export { LimitedTimeDropService } from './limited_drop.service';
+
+export * from './types/drop.types';
+export * from './types/access.types';
+export * from './constants/drop.constants';
+export * from './utils/drop.utils';
+
+export type {
+  AccessCheckResult,
+  AccessGrantRequest,
+  AccessList,
+  AccessRevokeRequest,
+  UserLevelUpdateRequest
+} from './types/access.types';
+
+export type {
+  BatchOperationResult,
+  Drop,
+  DropConfig,
+  DropId,
+  DropParticipationMetrics,
+  DropStatusSummary,
+  DropTimeRemaining,
+  DropUpdate,
+  EventListenerOptions,
+  EventSubscription,
+  HealthCheck,
+  LimitedDropEventData,
+  LimitedDropEventListener,
+  LimitedDropResponse,
+  LimitedDropServiceConfig,
+  NetworkConfig,
+  ParticipationOptions,
+  PerformanceMetrics,
+  PurchaseRecord,
+  TransactionResult,
+  UserAddress
+} from './types/drop.types';

--- a/src/shared/services/limited_time_drop/limited_drop.service.ts
+++ b/src/shared/services/limited_time_drop/limited_drop.service.ts
@@ -1,0 +1,875 @@
+import {
+  Client as LimitedTimeDropContractClient,
+  type Drop as ContractDrop
+} from '../../../../packages/limited_time_drop/src/index';
+import type { u32 } from '@stellar/stellar-sdk';
+import { signTransaction, getPublicKey, isWalletConnected } from '../../utils/wallet';
+import {
+  CACHE_KEYS,
+  DEFAULT_CONFIG,
+  ERROR_MESSAGES,
+  NETWORKS,
+  VALIDATION
+} from './constants/drop.constants';
+import {
+  calculateParticipationMetrics,
+  evaluateAccess,
+  fromContractDrop,
+  fromContractPurchaseRecord,
+  getDropStatusSummary,
+  getDropTimeRemaining,
+  getErrorType,
+  isValidDropId,
+  isValidQuantity,
+  isValidStellarAddress,
+  retryWithBackoff,
+  sanitizeString,
+  toContractDropStatus,
+  toContractUserLevel,
+  validateDropConfig
+} from './utils/drop.utils';
+import type {
+  BatchOperationResult,
+  Drop,
+  DropConfig,
+  DropId,
+  DropParticipationMetrics,
+  DropStatusSummary,
+  DropTimeRemaining,
+  DropUpdate,
+  EventListenerOptions,
+  EventSubscription,
+  HealthCheck,
+  LimitedDropEventData,
+  LimitedDropEventListener,
+  LimitedDropResponse,
+  LimitedDropServiceConfig,
+  NetworkConfig,
+  ParticipationOptions,
+  PerformanceMetrics,
+  PurchaseRecord,
+  TransactionResult,
+  UserAddress
+} from './types/drop.types';
+import { DropLifecycleStatus, LimitedDropEventType } from './types/drop.types';
+import type {
+  AccessCheckResult,
+  AccessGrantRequest,
+  AccessList,
+  AccessRevokeRequest,
+  UserLevelUpdateRequest
+} from './types/access.types';
+
+export class LimitedTimeDropService {
+  private contract: LimitedTimeDropContractClient;
+  private networkConfig: NetworkConfig;
+  private config: LimitedDropServiceConfig;
+  private cache: Map<string, { data: unknown; timestamp: number }> = new Map();
+  private eventListeners: Map<string, EventSubscription> = new Map();
+  private isInitialized = false;
+  private performanceMetrics: PerformanceMetrics = {
+    averageResponseTime: 0,
+    totalOperations: 0,
+    successfulOperations: 0,
+    failedOperations: 0,
+    cacheHitRate: 0,
+    lastUpdated: Date.now()
+  };
+
+  constructor(config?: Partial<LimitedDropServiceConfig>) {
+    this.config = {
+      network: NETWORKS.testnet,
+      timeoutInSeconds: DEFAULT_CONFIG.TIMEOUT_SECONDS,
+      fee: DEFAULT_CONFIG.FEE,
+      simulate: DEFAULT_CONFIG.SIMULATE,
+      retryConfig: DEFAULT_CONFIG.RETRY,
+      cache: DEFAULT_CONFIG.CACHE,
+      ...config
+    };
+
+    this.networkConfig = this.config.network;
+    this.contract = new LimitedTimeDropContractClient({
+      contractId: this.networkConfig.contractId,
+      networkPassphrase: this.networkConfig.networkPassphrase,
+      rpcUrl: this.networkConfig.rpcUrl
+    });
+  }
+
+  async initialize(config?: Partial<LimitedDropServiceConfig>): Promise<void> {
+    if (config) {
+      this.config = { ...this.config, ...config };
+      this.networkConfig = this.config.network;
+      this.contract = new LimitedTimeDropContractClient({
+        contractId: this.networkConfig.contractId,
+        networkPassphrase: this.networkConfig.networkPassphrase,
+        rpcUrl: this.networkConfig.rpcUrl
+      });
+    }
+
+    this.isInitialized = true;
+  }
+
+  async initializeContract(admin?: UserAddress): Promise<LimitedDropResponse<TransactionResult<void>>> {
+    try {
+      const adminAddress = await this.resolveSigner(admin);
+      if (!isValidStellarAddress(adminAddress)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_ADMIN);
+      }
+
+      const tx = await this.contract.initialize(
+        { admin: adminAddress },
+        this.transactionOptions()
+      );
+      const result = await this.signAndSendTransaction<void>(tx);
+
+      if (result.success) {
+        this.isInitialized = true;
+        this.emitEvent({
+          type: LimitedDropEventType.CONTRACT_INITIALIZED,
+          timestamp: Date.now(),
+          admin: adminAddress,
+          transactionHash: result.hash
+        });
+        return this.createSuccessResponse(result);
+      }
+
+      return this.createErrorResponse(result.error || 'Failed to initialize limited time drop contract');
+    } catch (error) {
+      return this.handleError(error, 'initializeContract');
+    }
+  }
+
+  async createDrop(config: DropConfig): Promise<LimitedDropResponse<DropId>> {
+    try {
+      const validation = validateDropConfig(config);
+      if (!validation.isValid) {
+        return this.createErrorResponse(validation.errors.join('; '));
+      }
+
+      const creator = await this.resolveSigner(config.creator);
+      if (!isValidStellarAddress(creator)) {
+        return this.createErrorResponse('Invalid creator address format');
+      }
+
+      const tx = await this.contract.create_drop(
+        {
+          creator,
+          title: sanitizeString(config.title, VALIDATION.DROP.TITLE_MAX_LENGTH),
+          product_id: config.productId,
+          max_supply: config.maxSupply,
+          start_time: config.startTime,
+          end_time: config.endTime,
+          price: config.price,
+          per_user_limit: config.perUserLimit,
+          image_uri: sanitizeString(config.imageUri || '', VALIDATION.DROP.IMAGE_URI_MAX_LENGTH)
+        },
+        this.transactionOptions()
+      );
+      const result = await this.signAndSendTransaction<DropId>(tx);
+
+      if (!result.success) {
+        return this.createErrorResponse(result.error || 'Failed to create drop');
+      }
+
+      const dropId = result.data;
+      this.emitEvent({
+        type: LimitedDropEventType.DROP_CREATED,
+        timestamp: Date.now(),
+        dropId,
+        user: creator,
+        transactionHash: result.hash
+      });
+
+      return this.createSuccessResponse(dropId as DropId);
+    } catch (error) {
+      return this.handleError(error, 'createDrop');
+    }
+  }
+
+  async getDrop(dropId: DropId): Promise<LimitedDropResponse<Drop>> {
+    try {
+      if (!isValidDropId(dropId)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_DROP_ID);
+      }
+
+      const cacheKey = CACHE_KEYS.DROP(dropId);
+      const cached = this.getCachedData<Drop>(cacheKey);
+      if (cached) {
+        return this.createSuccessResponse(cached);
+      }
+
+      const drop = await this.fetchDrop(dropId);
+      this.setCachedData(cacheKey, drop);
+      return this.createSuccessResponse(drop);
+    } catch (error) {
+      return this.handleError(error, 'getDrop');
+    }
+  }
+
+  async updateDrop(dropId: DropId, updates: DropUpdate): Promise<LimitedDropResponse<TransactionResult<void>>> {
+    try {
+      if (!isValidDropId(dropId)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_DROP_ID);
+      }
+
+      if (!updates.status) {
+        return this.createErrorResponse(ERROR_MESSAGES.UNSUPPORTED_DROP_UPDATE);
+      }
+
+      const admin = await this.resolveSigner(updates.admin);
+      if (!isValidStellarAddress(admin)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_ADMIN);
+      }
+
+      const tx = await this.contract.update_status(
+        {
+          admin,
+          drop_id: dropId,
+          status: toContractDropStatus(updates.status)
+        },
+        this.transactionOptions()
+      );
+      const result = await this.signAndSendTransaction<void>(tx);
+
+      if (!result.success) {
+        return this.createErrorResponse(result.error || 'Failed to update drop');
+      }
+
+      this.invalidateDropCache(dropId);
+      this.emitEvent({
+        type: LimitedDropEventType.DROP_UPDATED,
+        timestamp: Date.now(),
+        dropId,
+        admin,
+        status: updates.status,
+        transactionHash: result.hash
+      });
+
+      return this.createSuccessResponse(result);
+    } catch (error) {
+      return this.handleError(error, 'updateDrop');
+    }
+  }
+
+  async cancelDrop(dropId: DropId, admin?: UserAddress): Promise<LimitedDropResponse<TransactionResult<void>>> {
+    const result = await this.updateDrop(dropId, {
+      admin,
+      status: DropLifecycleStatus.CANCELLED
+    });
+
+    if (result.success) {
+      this.emitEvent({
+        type: LimitedDropEventType.DROP_CANCELLED,
+        timestamp: Date.now(),
+        dropId,
+        admin,
+        transactionHash: result.data?.hash
+      });
+    }
+
+    return result;
+  }
+
+  async checkAccess(dropId: DropId, user: UserAddress): Promise<LimitedDropResponse<AccessCheckResult>> {
+    try {
+      if (!isValidDropId(dropId)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_DROP_ID);
+      }
+
+      const cacheKey = CACHE_KEYS.ACCESS(user, dropId);
+      const cached = this.getCachedData<AccessCheckResult>(cacheKey);
+      if (cached) {
+        return this.createSuccessResponse(cached);
+      }
+
+      const drop = await this.fetchDrop(dropId);
+      const access = evaluateAccess(drop, user);
+      this.setCachedData(cacheKey, access);
+
+      return this.createSuccessResponse(access);
+    } catch (error) {
+      return this.handleError(error, 'checkAccess');
+    }
+  }
+
+  async grantAccess(
+    dropIdOrRequest: DropId | AccessGrantRequest,
+    user?: UserAddress,
+    admin?: UserAddress
+  ): Promise<LimitedDropResponse<TransactionResult<void>>> {
+    try {
+      const request: AccessGrantRequest = typeof dropIdOrRequest === 'object'
+        ? dropIdOrRequest
+        : { dropId: dropIdOrRequest, user: user ?? '', admin };
+
+      if (!isValidDropId(request.dropId)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_DROP_ID);
+      }
+
+      if (!isValidStellarAddress(request.user)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_USER);
+      }
+
+      const adminAddress = await this.resolveSigner(request.admin);
+      if (!isValidStellarAddress(adminAddress)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_ADMIN);
+      }
+
+      const tx = await this.contract.add_to_whitelist(
+        {
+          admin: adminAddress,
+          user: request.user
+        },
+        this.transactionOptions()
+      );
+      const result = await this.signAndSendTransaction<void>(tx);
+
+      if (!result.success) {
+        return this.createErrorResponse(result.error || 'Failed to grant access');
+      }
+
+      if (request.level) {
+        await this.updateUserLevel({ admin: adminAddress, user: request.user, level: request.level });
+      }
+
+      this.invalidateAccessCache(request.dropId, request.user);
+      this.emitEvent({
+        type: LimitedDropEventType.ACCESS_GRANTED,
+        timestamp: Date.now(),
+        dropId: request.dropId,
+        user: request.user,
+        admin: adminAddress,
+        transactionHash: result.hash
+      });
+
+      return this.createSuccessResponse(result);
+    } catch (error) {
+      return this.handleError(error, 'grantAccess');
+    }
+  }
+
+  async revokeAccess(
+    dropIdOrRequest: DropId | AccessRevokeRequest,
+    user?: UserAddress,
+    admin?: UserAddress
+  ): Promise<LimitedDropResponse<TransactionResult<void>>> {
+    try {
+      const request: AccessRevokeRequest = typeof dropIdOrRequest === 'object'
+        ? dropIdOrRequest
+        : { dropId: dropIdOrRequest, user: user ?? '', admin };
+
+      if (!isValidDropId(request.dropId)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_DROP_ID);
+      }
+
+      if (!isValidStellarAddress(request.user)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_USER);
+      }
+
+      const adminAddress = await this.resolveSigner(request.admin);
+      if (!isValidStellarAddress(adminAddress)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_ADMIN);
+      }
+
+      const tx = await this.contract.remove_from_whitelist(
+        {
+          admin: adminAddress,
+          user: request.user
+        },
+        this.transactionOptions()
+      );
+      const result = await this.signAndSendTransaction<void>(tx);
+
+      if (!result.success) {
+        return this.createErrorResponse(result.error || 'Failed to revoke access');
+      }
+
+      this.invalidateAccessCache(request.dropId, request.user);
+      this.emitEvent({
+        type: LimitedDropEventType.ACCESS_REVOKED,
+        timestamp: Date.now(),
+        dropId: request.dropId,
+        user: request.user,
+        admin: adminAddress,
+        transactionHash: result.hash
+      });
+
+      return this.createSuccessResponse(result);
+    } catch (error) {
+      return this.handleError(error, 'revokeAccess');
+    }
+  }
+
+  async getAccessList(dropId: DropId): Promise<LimitedDropResponse<AccessList>> {
+    try {
+      if (!isValidDropId(dropId)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_DROP_ID);
+      }
+
+      const cacheKey = CACHE_KEYS.BUYER_LIST(dropId);
+      const cached = this.getCachedData<AccessList>(cacheKey);
+      if (cached) {
+        return this.createSuccessResponse(cached);
+      }
+
+      const tx = await this.contract.get_buyer_list({ drop_id: dropId });
+      const result = await tx.simulate();
+      const users = result.result;
+      const accessList: AccessList = {
+        dropId,
+        users,
+        total: users.length as u32,
+        source: 'contract_buyers'
+      };
+
+      this.setCachedData(cacheKey, accessList);
+      return this.createSuccessResponse(accessList);
+    } catch (error) {
+      return this.handleError(error, 'getAccessList');
+    }
+  }
+
+  async participateInDrop(
+    dropId: DropId,
+    options: ParticipationOptions = {}
+  ): Promise<LimitedDropResponse<TransactionResult<void>>> {
+    try {
+      if (!isValidDropId(dropId)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_DROP_ID);
+      }
+
+      const quantity = options.quantity ?? 1;
+      if (!isValidQuantity(quantity)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_QUANTITY);
+      }
+
+      const buyer = await this.resolveSigner(options.buyer);
+      if (!isValidStellarAddress(buyer)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_USER);
+      }
+
+      const access = await this.checkAccess(dropId, buyer);
+      if (!access.success || !access.data?.hasAccess) {
+        return this.createErrorResponse(access.data?.reason || access.error || 'User cannot access this drop');
+      }
+
+      const tx = await this.contract.purchase(
+        {
+          buyer,
+          drop_id: dropId,
+          quantity
+        },
+        this.transactionOptions()
+      );
+      const result = await this.signAndSendTransaction<void>(tx);
+
+      if (!result.success) {
+        return this.createErrorResponse(result.error || 'Failed to participate in drop');
+      }
+
+      this.invalidateDropCache(dropId);
+      this.emitEvent({
+        type: LimitedDropEventType.USER_PARTICIPATED,
+        timestamp: Date.now(),
+        dropId,
+        user: buyer,
+        transactionHash: result.hash
+      });
+
+      return this.createSuccessResponse(result);
+    } catch (error) {
+      return this.handleError(error, 'participateInDrop');
+    }
+  }
+
+  async trackParticipation(dropId: DropId): Promise<LimitedDropResponse<DropParticipationMetrics>> {
+    try {
+      if (!isValidDropId(dropId)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_DROP_ID);
+      }
+
+      const cacheKey = CACHE_KEYS.DROP_PURCHASES(dropId);
+      const cached = this.getCachedData<DropParticipationMetrics>(cacheKey);
+      if (cached) {
+        return this.createSuccessResponse(cached);
+      }
+
+      const drop = await this.fetchDrop(dropId);
+      const purchasesTx = await this.contract.get_drop_purchases({ drop_id: dropId });
+      const buyersTx = await this.contract.get_buyer_list({ drop_id: dropId });
+      const [purchasesResult, buyersResult] = await Promise.all([
+        purchasesTx.simulate(),
+        buyersTx.simulate()
+      ]);
+
+      const metrics = calculateParticipationMetrics(
+        drop,
+        purchasesResult.result,
+        buyersResult.result.length as u32
+      );
+      this.setCachedData(cacheKey, metrics);
+
+      return this.createSuccessResponse(metrics);
+    } catch (error) {
+      return this.handleError(error, 'trackParticipation');
+    }
+  }
+
+  async getDropStatus(dropId: DropId): Promise<LimitedDropResponse<DropStatusSummary>> {
+    try {
+      const drop = await this.fetchDrop(dropId);
+      return this.createSuccessResponse(getDropStatusSummary(drop));
+    } catch (error) {
+      return this.handleError(error, 'getDropStatus');
+    }
+  }
+
+  async isDropActive(dropId: DropId): Promise<LimitedDropResponse<boolean>> {
+    const status = await this.getDropStatus(dropId);
+    if (!status.success) {
+      return this.createErrorResponse(status.error || 'Failed to get drop status');
+    }
+
+    return this.createSuccessResponse(Boolean(status.data?.isActive));
+  }
+
+  async getTimeRemaining(dropId: DropId): Promise<LimitedDropResponse<DropTimeRemaining>> {
+    try {
+      const drop = await this.fetchDrop(dropId);
+      return this.createSuccessResponse(getDropTimeRemaining(drop));
+    } catch (error) {
+      return this.handleError(error, 'getTimeRemaining');
+    }
+  }
+
+  async extendDrop(
+    dropId: DropId,
+    durationSeconds: number | bigint,
+    admin?: UserAddress
+  ): Promise<LimitedDropResponse<TransactionResult<void>>> {
+    void dropId;
+    void durationSeconds;
+    void admin;
+    return this.createErrorResponse(ERROR_MESSAGES.UNSUPPORTED_DROP_EXTENSION);
+  }
+
+  async updateUserLevel(request: UserLevelUpdateRequest): Promise<LimitedDropResponse<TransactionResult<void>>> {
+    try {
+      if (!isValidStellarAddress(request.user)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_USER);
+      }
+
+      const adminAddress = await this.resolveSigner(request.admin);
+      if (!isValidStellarAddress(adminAddress)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_ADMIN);
+      }
+
+      const tx = await this.contract.set_user_level(
+        {
+          admin: adminAddress,
+          user: request.user,
+          level: toContractUserLevel(request.level)
+        },
+        this.transactionOptions()
+      );
+      const result = await this.signAndSendTransaction<void>(tx);
+
+      if (!result.success) {
+        return this.createErrorResponse(result.error || 'Failed to update user level');
+      }
+
+      this.emitEvent({
+        type: LimitedDropEventType.USER_LEVEL_UPDATED,
+        timestamp: Date.now(),
+        user: request.user,
+        admin: adminAddress,
+        transactionHash: result.hash
+      });
+
+      return this.createSuccessResponse(result);
+    } catch (error) {
+      return this.handleError(error, 'updateUserLevel');
+    }
+  }
+
+  async getPurchaseHistory(user: UserAddress, dropId: DropId): Promise<LimitedDropResponse<PurchaseRecord[]>> {
+    try {
+      if (!isValidStellarAddress(user)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_USER);
+      }
+
+      if (!isValidDropId(dropId)) {
+        return this.createErrorResponse(ERROR_MESSAGES.INVALID_DROP_ID);
+      }
+
+      const cacheKey = CACHE_KEYS.PURCHASE_HISTORY(user, dropId);
+      const cached = this.getCachedData<PurchaseRecord[]>(cacheKey);
+      if (cached) {
+        return this.createSuccessResponse(cached);
+      }
+
+      const tx = await this.contract.get_purchase_history({ user, drop_id: dropId });
+      const result = await tx.simulate();
+      const records = result.result.map(fromContractPurchaseRecord);
+
+      this.setCachedData(cacheKey, records);
+      return this.createSuccessResponse(records);
+    } catch (error) {
+      return this.handleError(error, 'getPurchaseHistory');
+    }
+  }
+
+  async batchCheckAccess(dropId: DropId, users: UserAddress[]): Promise<LimitedDropResponse<BatchOperationResult<AccessCheckResult>>> {
+    const successful: AccessCheckResult[] = [];
+    const failed: Array<{ input: unknown; error: string }> = [];
+
+    for (const user of users) {
+      const result = await this.checkAccess(dropId, user);
+      if (result.success && result.data) {
+        successful.push(result.data);
+      } else {
+        failed.push({ input: user, error: result.error || 'Unknown access check error' });
+      }
+    }
+
+    return this.createSuccessResponse({
+      successful,
+      failed,
+      totalProcessed: users.length
+    });
+  }
+
+  async performHealthCheck(): Promise<HealthCheck> {
+    const errors: string[] = [];
+
+    try {
+      if (!this.networkConfig.contractId || !this.networkConfig.networkPassphrase || !this.networkConfig.rpcUrl) {
+        errors.push('Invalid network configuration');
+      }
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : 'Unknown health check error');
+    }
+
+    return {
+      isHealthy: errors.length === 0,
+      network: this.networkConfig.isTestnet ? 'testnet' : 'mainnet',
+      contractId: this.networkConfig.contractId,
+      timestamp: Date.now(),
+      errors
+    };
+  }
+
+  getPerformanceMetrics(): PerformanceMetrics {
+    return { ...this.performanceMetrics };
+  }
+
+  addEventListener(
+    eventTypes: LimitedDropEventType[],
+    listener: LimitedDropEventListener,
+    options: EventListenerOptions = {}
+  ): string {
+    const id = `limited_drop_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+    this.eventListeners.set(id, {
+      id,
+      eventTypes,
+      listener,
+      active: true,
+      options
+    });
+    return id;
+  }
+
+  removeEventListener(subscriptionId: string): boolean {
+    return this.eventListeners.delete(subscriptionId);
+  }
+
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  destroy(): void {
+    this.eventListeners.clear();
+    this.cache.clear();
+    this.isInitialized = false;
+  }
+
+  private async fetchDrop(dropId: DropId): Promise<Drop> {
+    if (!isValidDropId(dropId)) {
+      throw new Error(ERROR_MESSAGES.INVALID_DROP_ID);
+    }
+
+    const tx = await retryWithBackoff(
+      () => this.contract.get_drop({ drop_id: dropId }),
+      this.config.retryConfig.maxRetries,
+      this.config.retryConfig.baseDelay,
+      this.config.retryConfig.maxDelay,
+      this.config.retryConfig.backoffMultiplier
+    );
+    const result = await tx.simulate();
+    return fromContractDrop(result.result as ContractDrop);
+  }
+
+  private async resolveSigner(address?: UserAddress): Promise<UserAddress> {
+    if (address) {
+      return address;
+    }
+
+    const connected = await isWalletConnected();
+    if (!connected) {
+      throw new Error(ERROR_MESSAGES.WALLET_NOT_CONNECTED);
+    }
+
+    const publicKey = await getPublicKey();
+    if (!publicKey) {
+      throw new Error(ERROR_MESSAGES.WALLET_NOT_CONNECTED);
+    }
+
+    return publicKey;
+  }
+
+  private transactionOptions(): { fee: number; timeoutInSeconds: number; simulate: boolean } {
+    return {
+      fee: this.config.fee,
+      timeoutInSeconds: this.config.timeoutInSeconds,
+      simulate: this.config.simulate
+    };
+  }
+
+  private async signAndSendTransaction<T>(tx: any): Promise<TransactionResult<T>> {
+    const startTime = Date.now();
+
+    try {
+      const xdr = tx.toXDR();
+      const signedXdr = await signTransaction(xdr, this.networkConfig.isTestnet ? 'TESTNET' : 'MAINNET');
+      const result = await tx.signAndSend(signedXdr);
+      const responseTime = Date.now() - startTime;
+      this.updatePerformanceMetrics(true, responseTime);
+
+      return {
+        hash: result.hash || '',
+        success: true,
+        gasUsed: result.gasUsed,
+        fee: result.fee,
+        data: tx.result as T
+      };
+    } catch (error) {
+      const responseTime = Date.now() - startTime;
+      this.updatePerformanceMetrics(false, responseTime);
+
+      return {
+        hash: '',
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      };
+    }
+  }
+
+  private getCachedData<T>(key: string): T | null {
+    if (!this.config.cache.enabled) {
+      return null;
+    }
+
+    const cached = this.cache.get(key);
+    if (!cached) {
+      return null;
+    }
+
+    if (Date.now() - cached.timestamp > this.config.cache.ttl) {
+      this.cache.delete(key);
+      return null;
+    }
+
+    return cached.data as T;
+  }
+
+  private setCachedData(key: string, data: unknown): void {
+    if (!this.config.cache.enabled) {
+      return;
+    }
+
+    if (this.cache.size >= this.config.cache.maxSize) {
+      const firstKey = this.cache.keys().next().value as string | undefined;
+      if (firstKey) {
+        this.cache.delete(firstKey);
+      }
+    }
+
+    this.cache.set(key, { data, timestamp: Date.now() });
+  }
+
+  private invalidateDropCache(dropId: DropId): void {
+    this.cache.delete(CACHE_KEYS.DROP(dropId));
+    this.cache.delete(CACHE_KEYS.DROP_STATUS(dropId));
+    this.cache.delete(CACHE_KEYS.DROP_PURCHASES(dropId));
+    this.cache.delete(CACHE_KEYS.BUYER_LIST(dropId));
+  }
+
+  private invalidateAccessCache(dropId: DropId, user: UserAddress): void {
+    this.cache.delete(CACHE_KEYS.ACCESS(user, dropId));
+    this.cache.delete(CACHE_KEYS.BUYER_LIST(dropId));
+  }
+
+  private updatePerformanceMetrics(success: boolean, responseTime: number): void {
+    this.performanceMetrics.totalOperations += 1;
+    this.performanceMetrics.lastUpdated = Date.now();
+
+    if (success) {
+      this.performanceMetrics.successfulOperations += 1;
+    } else {
+      this.performanceMetrics.failedOperations += 1;
+    }
+
+    const totalResponseTime =
+      this.performanceMetrics.averageResponseTime * (this.performanceMetrics.totalOperations - 1) + responseTime;
+    this.performanceMetrics.averageResponseTime = totalResponseTime / this.performanceMetrics.totalOperations;
+  }
+
+  private emitEvent(event: LimitedDropEventData): void {
+    for (const subscription of this.eventListeners.values()) {
+      if (!subscription.active || !subscription.eventTypes.includes(event.type)) {
+        continue;
+      }
+
+      if (subscription.options.dropId && subscription.options.dropId !== event.dropId) {
+        continue;
+      }
+
+      if (subscription.options.userAddress && subscription.options.userAddress !== event.user) {
+        continue;
+      }
+
+      try {
+        subscription.listener(event);
+      } catch (error) {
+        console.error('Error in limited drop event listener:', error);
+      }
+    }
+  }
+
+  private handleError(error: unknown, operation: string): LimitedDropResponse<never> {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    this.emitEvent({
+      type: LimitedDropEventType.ERROR,
+      timestamp: Date.now(),
+      error: errorMessage,
+      operation
+    });
+
+    return this.createErrorResponse(errorMessage, getErrorType(errorMessage));
+  }
+
+  private createSuccessResponse<T>(data: T): LimitedDropResponse<T> {
+    return {
+      success: true,
+      data
+    };
+  }
+
+  private createErrorResponse<T = never>(error: string, errorCode?: number | string): LimitedDropResponse<T> {
+    return {
+      success: false,
+      error,
+      errorCode
+    };
+  }
+}

--- a/src/shared/services/limited_time_drop/types/access.types.ts
+++ b/src/shared/services/limited_time_drop/types/access.types.ts
@@ -1,0 +1,39 @@
+import type { u32 } from '@stellar/stellar-sdk';
+import type { DropId, DropLifecycleStatus, UserAccessLevel, UserAddress } from './drop.types';
+
+export interface AccessCheckResult {
+  dropId: DropId;
+  user: UserAddress;
+  hasAccess: boolean;
+  reason?: string;
+  userLevel?: UserAccessLevel;
+  dropStatus: DropLifecycleStatus;
+  isWithinDropWindow: boolean;
+  hasAvailableSupply: boolean;
+}
+
+export interface AccessGrantRequest {
+  dropId: DropId;
+  user: UserAddress;
+  admin?: UserAddress;
+  level?: UserAccessLevel;
+}
+
+export interface AccessRevokeRequest {
+  dropId: DropId;
+  user: UserAddress;
+  admin?: UserAddress;
+}
+
+export interface AccessList {
+  dropId: DropId;
+  users: UserAddress[];
+  total: u32;
+  source: 'contract_buyers' | 'local_cache';
+}
+
+export interface UserLevelUpdateRequest {
+  user: UserAddress;
+  admin?: UserAddress;
+  level: UserAccessLevel;
+}

--- a/src/shared/services/limited_time_drop/types/drop.types.ts
+++ b/src/shared/services/limited_time_drop/types/drop.types.ts
@@ -1,0 +1,205 @@
+import type { u32, u64, i128 } from '@stellar/stellar-sdk';
+
+export type DropId = u32;
+export type UserAddress = string;
+export type ContractAddress = string;
+export type TransactionHash = string;
+
+export enum DropLifecycleStatus {
+  PENDING = 'pending',
+  ACTIVE = 'active',
+  COMPLETED = 'completed',
+  CANCELLED = 'cancelled'
+}
+
+export enum UserAccessLevel {
+  STANDARD = 'standard',
+  PREMIUM = 'premium',
+  VERIFIED = 'verified'
+}
+
+export enum LimitedDropEventType {
+  CONTRACT_INITIALIZED = 'contract_initialized',
+  DROP_CREATED = 'drop_created',
+  DROP_UPDATED = 'drop_updated',
+  DROP_CANCELLED = 'drop_cancelled',
+  USER_PARTICIPATED = 'user_participated',
+  ACCESS_GRANTED = 'access_granted',
+  ACCESS_REVOKED = 'access_revoked',
+  USER_LEVEL_UPDATED = 'user_level_updated',
+  ERROR = 'error'
+}
+
+export interface NetworkConfig {
+  contractId: ContractAddress;
+  networkPassphrase: string;
+  rpcUrl: string;
+  isTestnet: boolean;
+}
+
+export interface RetryConfig {
+  maxRetries: number;
+  baseDelay: number;
+  maxDelay: number;
+  backoffMultiplier: number;
+}
+
+export interface CacheConfig {
+  enabled: boolean;
+  ttl: number;
+  maxSize: number;
+}
+
+export interface LimitedDropServiceConfig {
+  network: NetworkConfig;
+  timeoutInSeconds: number;
+  fee: number;
+  simulate: boolean;
+  retryConfig: RetryConfig;
+  cache: CacheConfig;
+}
+
+export interface LimitedDropResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  errorCode?: number | string;
+  transactionHash?: TransactionHash;
+  fee?: number;
+}
+
+export interface TransactionResult<T = unknown> {
+  hash: TransactionHash;
+  success: boolean;
+  error?: string;
+  gasUsed?: number;
+  fee?: number;
+  data?: T;
+}
+
+export interface DropConfig {
+  creator?: UserAddress;
+  title: string;
+  productId: u64;
+  maxSupply: u32;
+  startTime: u64;
+  endTime: u64;
+  price: i128;
+  perUserLimit: u32;
+  imageUri: string;
+}
+
+export interface Drop {
+  id: DropId;
+  creator: UserAddress;
+  title: string;
+  productId: u64;
+  maxSupply: u32;
+  startTime: u64;
+  endTime: u64;
+  price: i128;
+  perUserLimit: u32;
+  imageUri: string;
+  status: DropLifecycleStatus;
+  totalPurchased: u32;
+}
+
+export interface DropUpdate {
+  admin?: UserAddress;
+  status?: DropLifecycleStatus;
+}
+
+export interface ParticipationOptions {
+  buyer?: UserAddress;
+  quantity?: u32;
+}
+
+export interface DropParticipationMetrics {
+  dropId: DropId;
+  totalPurchased: u32;
+  buyerCount: u32;
+  remainingSupply: u32;
+  soldOut: boolean;
+  purchaseRate: number;
+}
+
+export interface DropStatusSummary {
+  dropId: DropId;
+  status: DropLifecycleStatus;
+  isActive: boolean;
+  isPending: boolean;
+  isCompleted: boolean;
+  isCancelled: boolean;
+  hasStarted: boolean;
+  hasEnded: boolean;
+  remainingSupply: u32;
+}
+
+export interface DropTimeRemaining {
+  dropId: DropId;
+  remainingSeconds: number;
+  isStarted: boolean;
+  isEnded: boolean;
+  startsInSeconds: number;
+  endsAt: u64;
+}
+
+export interface PurchaseRecord {
+  dropId: DropId;
+  quantity: u32;
+  pricePaid: i128;
+  timestamp: u64;
+}
+
+export interface HealthCheck {
+  isHealthy: boolean;
+  network: string;
+  contractId: ContractAddress;
+  timestamp: number;
+  errors: string[];
+}
+
+export interface PerformanceMetrics {
+  averageResponseTime: number;
+  totalOperations: number;
+  successfulOperations: number;
+  failedOperations: number;
+  cacheHitRate: number;
+  lastUpdated: number;
+}
+
+export interface LimitedDropEventData {
+  type: LimitedDropEventType;
+  timestamp: number;
+  dropId?: DropId;
+  user?: UserAddress;
+  admin?: UserAddress;
+  status?: DropLifecycleStatus;
+  transactionHash?: TransactionHash;
+  error?: string;
+  operation?: string;
+}
+
+export type LimitedDropEventListener = (event: LimitedDropEventData) => void;
+
+export interface EventListenerOptions {
+  dropId?: DropId;
+  userAddress?: UserAddress;
+}
+
+export interface EventSubscription {
+  id: string;
+  eventTypes: LimitedDropEventType[];
+  listener: LimitedDropEventListener;
+  active: boolean;
+  options: EventListenerOptions;
+}
+
+export interface BatchOperationResult<T = unknown> {
+  successful: T[];
+  failed: Array<{
+    input: unknown;
+    error: string;
+  }>;
+  totalProcessed: number;
+}

--- a/src/shared/services/limited_time_drop/utils/drop.utils.ts
+++ b/src/shared/services/limited_time_drop/utils/drop.utils.ts
@@ -1,0 +1,348 @@
+import type {
+  Drop as ContractDrop,
+  DropStatus as ContractDropStatus,
+  PurchaseRecord as ContractPurchaseRecord,
+  UserLevel as ContractUserLevel
+} from '../../../../../packages/limited_time_drop/src/index';
+import type { u32, u64 } from '@stellar/stellar-sdk';
+import {
+  Drop,
+  DropConfig,
+  DropId,
+  DropLifecycleStatus,
+  DropParticipationMetrics,
+  DropStatusSummary,
+  DropTimeRemaining,
+  PurchaseRecord,
+  UserAccessLevel
+} from '../types/drop.types';
+import { AccessCheckResult } from '../types/access.types';
+import { CONTRACT_ERROR_CODES, VALIDATION } from '../constants/drop.constants';
+
+export function isValidStellarAddress(address: string): boolean {
+  return typeof address === 'string' && VALIDATION.ADDRESS.PATTERN.test(address);
+}
+
+export function isValidDropId(dropId: DropId): boolean {
+  return typeof dropId === 'number' && Number.isInteger(dropId) && dropId > 0;
+}
+
+export function isValidQuantity(quantity: u32): boolean {
+  return (
+    typeof quantity === 'number' &&
+    Number.isInteger(quantity) &&
+    quantity >= VALIDATION.PARTICIPATION.MIN_QUANTITY &&
+    quantity <= VALIDATION.PARTICIPATION.MAX_QUANTITY
+  );
+}
+
+export function sanitizeString(value: string, maxLength: number): string {
+  return value.trim().slice(0, maxLength);
+}
+
+export function validateDropConfig(config: DropConfig): { isValid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  if (config.creator && !isValidStellarAddress(config.creator)) {
+    errors.push('Creator address is invalid');
+  }
+
+  if (!config.title || config.title.trim().length === 0) {
+    errors.push('Title is required');
+  }
+
+  if (config.title.length > VALIDATION.DROP.TITLE_MAX_LENGTH) {
+    errors.push(`Title must be ${VALIDATION.DROP.TITLE_MAX_LENGTH} characters or fewer`);
+  }
+
+  if (typeof config.productId !== 'bigint' || config.productId <= 0n) {
+    errors.push('Product ID must be a positive bigint');
+  }
+
+  if (
+    typeof config.maxSupply !== 'number' ||
+    config.maxSupply < VALIDATION.DROP.MIN_SUPPLY ||
+    config.maxSupply > VALIDATION.DROP.MAX_SUPPLY
+  ) {
+    errors.push(`Max supply must be between ${VALIDATION.DROP.MIN_SUPPLY} and ${VALIDATION.DROP.MAX_SUPPLY}`);
+  }
+
+  if (typeof config.startTime !== 'bigint' || typeof config.endTime !== 'bigint') {
+    errors.push('Start time and end time must be bigint Unix timestamps');
+  } else {
+    if (config.endTime <= config.startTime) {
+      errors.push('End time must be after start time');
+    }
+
+    const duration = config.endTime - config.startTime;
+    if (duration < VALIDATION.DROP.MIN_DURATION_SECONDS || duration > VALIDATION.DROP.MAX_DURATION_SECONDS) {
+      errors.push(
+        `Drop duration must be between ${VALIDATION.DROP.MIN_DURATION_SECONDS} and ${VALIDATION.DROP.MAX_DURATION_SECONDS} seconds`
+      );
+    }
+  }
+
+  if (typeof config.price !== 'bigint' || config.price < VALIDATION.DROP.MIN_PRICE) {
+    errors.push('Price must be a non-negative bigint');
+  }
+
+  if (
+    typeof config.perUserLimit !== 'number' ||
+    config.perUserLimit < VALIDATION.DROP.MIN_PER_USER_LIMIT ||
+    config.perUserLimit > VALIDATION.DROP.MAX_PER_USER_LIMIT
+  ) {
+    errors.push(
+      `Per-user limit must be between ${VALIDATION.DROP.MIN_PER_USER_LIMIT} and ${VALIDATION.DROP.MAX_PER_USER_LIMIT}`
+    );
+  }
+
+  if (config.perUserLimit > config.maxSupply) {
+    errors.push('Per-user limit cannot exceed max supply');
+  }
+
+  if (config.imageUri && config.imageUri.length > VALIDATION.DROP.IMAGE_URI_MAX_LENGTH) {
+    errors.push(`Image URI must be ${VALIDATION.DROP.IMAGE_URI_MAX_LENGTH} characters or fewer`);
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors
+  };
+}
+
+export function toContractDropStatus(status: DropLifecycleStatus): ContractDropStatus {
+  switch (status) {
+    case DropLifecycleStatus.PENDING:
+      return { tag: 'Pending', values: undefined };
+    case DropLifecycleStatus.ACTIVE:
+      return { tag: 'Active', values: undefined };
+    case DropLifecycleStatus.COMPLETED:
+      return { tag: 'Completed', values: undefined };
+    case DropLifecycleStatus.CANCELLED:
+      return { tag: 'Cancelled', values: undefined };
+    default:
+      return { tag: 'Pending', values: undefined };
+  }
+}
+
+export function fromContractDropStatus(status: ContractDropStatus): DropLifecycleStatus {
+  switch (status.tag) {
+    case 'Active':
+      return DropLifecycleStatus.ACTIVE;
+    case 'Completed':
+      return DropLifecycleStatus.COMPLETED;
+    case 'Cancelled':
+      return DropLifecycleStatus.CANCELLED;
+    case 'Pending':
+    default:
+      return DropLifecycleStatus.PENDING;
+  }
+}
+
+export function toContractUserLevel(level: UserAccessLevel): ContractUserLevel {
+  switch (level) {
+    case UserAccessLevel.PREMIUM:
+      return { tag: 'Premium', values: undefined };
+    case UserAccessLevel.VERIFIED:
+      return { tag: 'Verified', values: undefined };
+    case UserAccessLevel.STANDARD:
+    default:
+      return { tag: 'Standard', values: undefined };
+  }
+}
+
+export function fromContractDrop(drop: ContractDrop): Drop {
+  return {
+    id: drop.id,
+    creator: drop.creator,
+    title: drop.title,
+    productId: drop.product_id,
+    maxSupply: drop.max_supply,
+    startTime: drop.start_time,
+    endTime: drop.end_time,
+    price: drop.price,
+    perUserLimit: drop.per_user_limit,
+    imageUri: drop.image_uri,
+    status: fromContractDropStatus(drop.status),
+    totalPurchased: drop.total_purchased
+  };
+}
+
+export function fromContractPurchaseRecord(record: ContractPurchaseRecord): PurchaseRecord {
+  return {
+    dropId: record.drop_id,
+    quantity: record.quantity,
+    pricePaid: record.price_paid,
+    timestamp: record.timestamp
+  };
+}
+
+export function getCurrentUnixTimestamp(): u64 {
+  return BigInt(Math.floor(Date.now() / 1000));
+}
+
+export function isDropWithinWindow(drop: Drop, now: u64 = getCurrentUnixTimestamp()): boolean {
+  return now >= drop.startTime && now <= drop.endTime;
+}
+
+export function isDropActive(drop: Drop, now: u64 = getCurrentUnixTimestamp()): boolean {
+  return (
+    drop.status === DropLifecycleStatus.ACTIVE &&
+    isDropWithinWindow(drop, now) &&
+    drop.totalPurchased < drop.maxSupply
+  );
+}
+
+export function getDropTimeRemaining(drop: Drop, now: u64 = getCurrentUnixTimestamp()): DropTimeRemaining {
+  const isStarted = now >= drop.startTime;
+  const isEnded = now >= drop.endTime;
+  const startsInSeconds = isStarted ? 0 : Number(drop.startTime - now);
+  const remainingSeconds = isEnded ? 0 : Number(drop.endTime - now);
+
+  return {
+    dropId: drop.id,
+    remainingSeconds,
+    isStarted,
+    isEnded,
+    startsInSeconds,
+    endsAt: drop.endTime
+  };
+}
+
+export function getDropStatusSummary(drop: Drop, now: u64 = getCurrentUnixTimestamp()): DropStatusSummary {
+  const remainingSupply = Math.max(0, drop.maxSupply - drop.totalPurchased) as u32;
+
+  return {
+    dropId: drop.id,
+    status: drop.status,
+    isActive: isDropActive(drop, now),
+    isPending: drop.status === DropLifecycleStatus.PENDING,
+    isCompleted: drop.status === DropLifecycleStatus.COMPLETED,
+    isCancelled: drop.status === DropLifecycleStatus.CANCELLED,
+    hasStarted: now >= drop.startTime,
+    hasEnded: now >= drop.endTime,
+    remainingSupply,
+  };
+}
+
+export function calculateParticipationMetrics(
+  drop: Drop,
+  totalPurchased: u32,
+  buyerCount: u32
+): DropParticipationMetrics {
+  const remainingSupply = Math.max(0, drop.maxSupply - totalPurchased) as u32;
+
+  return {
+    dropId: drop.id,
+    totalPurchased,
+    buyerCount,
+    remainingSupply,
+    soldOut: remainingSupply === 0,
+    purchaseRate: drop.maxSupply > 0 ? Number(((totalPurchased / drop.maxSupply) * 100).toFixed(2)) : 0
+  };
+}
+
+export function evaluateAccess(drop: Drop, user: string): AccessCheckResult {
+  const status = getDropStatusSummary(drop);
+
+  if (!isValidStellarAddress(user)) {
+    return {
+      dropId: drop.id,
+      user,
+      hasAccess: false,
+      reason: 'Invalid user address',
+      dropStatus: drop.status,
+      isWithinDropWindow: status.hasStarted && !status.hasEnded,
+      hasAvailableSupply: status.remainingSupply > 0
+    };
+  }
+
+  if (drop.status === DropLifecycleStatus.CANCELLED) {
+    return {
+      dropId: drop.id,
+      user,
+      hasAccess: false,
+      reason: 'Drop is cancelled',
+      dropStatus: drop.status,
+      isWithinDropWindow: false,
+      hasAvailableSupply: status.remainingSupply > 0
+    };
+  }
+
+  if (!status.hasStarted) {
+    return {
+      dropId: drop.id,
+      user,
+      hasAccess: false,
+      reason: 'Drop has not started',
+      dropStatus: drop.status,
+      isWithinDropWindow: false,
+      hasAvailableSupply: status.remainingSupply > 0
+    };
+  }
+
+  if (status.hasEnded) {
+    return {
+      dropId: drop.id,
+      user,
+      hasAccess: false,
+      reason: 'Drop has ended',
+      dropStatus: drop.status,
+      isWithinDropWindow: false,
+      hasAvailableSupply: status.remainingSupply > 0
+    };
+  }
+
+  if (status.remainingSupply <= 0) {
+    return {
+      dropId: drop.id,
+      user,
+      hasAccess: false,
+      reason: 'Drop is sold out',
+      dropStatus: drop.status,
+      isWithinDropWindow: true,
+      hasAvailableSupply: false
+    };
+  }
+
+  return {
+    dropId: drop.id,
+    user,
+    hasAccess: status.isActive,
+    reason: status.isActive ? undefined : 'Drop is not active',
+    dropStatus: drop.status,
+    isWithinDropWindow: true,
+    hasAvailableSupply: true
+  };
+}
+
+export function getErrorType(message: string): string {
+  const match = Object.entries(CONTRACT_ERROR_CODES).find(([, value]) => message.includes(value));
+  return match ? match[1] : 'UnknownError';
+}
+
+export async function retryWithBackoff<T>(
+  operation: () => Promise<T>,
+  maxRetries: number,
+  baseDelay: number,
+  maxDelay: number,
+  backoffMultiplier: number
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxRetries) {
+        break;
+      }
+
+      const delay = Math.min(baseDelay * Math.pow(backoffMultiplier, attempt), maxDelay);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}


### PR DESCRIPTION
# 🚀 StarShop Pull Request

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [x] Closes #282
- [ ] Added tests (if necessary)
- [ ] Run tests
- [ ] Run formatting
- [ ] Evidence attached
- [ ] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

- Add a LimitedTimeDropService wrapper for create/get/update/cancel/access/participation/status/time helpers.
- Add typed drop/access models, constants, validation utilities, cache/event helpers, and README usage notes.
- Document current generated-contract limitations for whitelist listing and end-time extension.

---

## 📸 Evidence (A photo is required as evidence)

Not applicable; service-layer code change.

---

## ⏰ Time spent breakdown

- Implementation: 1h
- Local review/diff check: 15m

---

## 🌌 Comments

Validation: ran `git diff --check` locally and fetched the fork branch back to compare against the local tree. Full type/lint test not run because this environment has no npm/pnpm/yarn/tsc available.

Closes #282
